### PR TITLE
fix: change from `master` to `main`

### DIFF
--- a/scripts/clone.sh
+++ b/scripts/clone.sh
@@ -3,7 +3,7 @@
 set -e # Exit with nonzero exit code if anything fails 
 
 cd /home/developer/nodejs
-git clone https://github.com/nodejs/node.git --single-branch --branch master --depth 1
+git clone https://github.com/nodejs/node.git --single-branch --branch main --depth 1
 cd /home/developer/nodejs/node
 git remote add upstream https://github.com/nodejs/node.git
 git fetch upstream

--- a/scripts/ncu.sh
+++ b/scripts/ncu.sh
@@ -5,4 +5,4 @@ set -e # Exit with nonzero exit code if anything fails
 npm install -g node-core-utils
 
 ncu-config set upstream upstream
-ncu-config set branch master
+ncu-config set branch main


### PR DESCRIPTION
updates from `master` to `main` which was seemingly the cause of the failure (based off of local build failure + this change making the build succeed) in the [first attempted run](https://github.com/nodejs/devcontainer/actions/runs/2618885744) under the Node.js org. 