### PR TITLE
Split build workflows for different platforms

### DIFF
--- a/.github/workflows/docker-build-and-publish-linux-amd64.yml
+++ b/.github/workflows/docker-build-and-publish-linux-amd64.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   docker:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == format('refs/heads/{0}', vars.NIGHTLY_BRANCH) }}
     runs-on: ubuntu-24.04
-    steps:
+    steps: # See https://docs.docker.com/build/ci/github-actions/multi-platform/
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with: # these are defined in the GitHub Secrets UI
@@ -24,4 +24,4 @@ jobs:
         with:
           platforms: linux/amd64
           push: true
-          tags: nodejs/devcontainer:nightly-linux-amd64
+          tags: ${{ vars.DOCKERHUB_IMAGE }}:nightly-linux-amd64

--- a/.github/workflows/docker-build-and-publish-linux-amd64.yml
+++ b/.github/workflows/docker-build-and-publish-linux-amd64.yml
@@ -1,0 +1,27 @@
+name: Build and Publish Linux AMD64 Image
+
+on:
+  workflow_dispatch: # allows us to trigger runs manually in the GitHub UI
+  schedule:
+    - cron:  '0 0 * * *' # runs nightly
+
+jobs:
+  docker:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with: # these are defined in the GitHub Secrets UI
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: nodejs/devcontainer:nightly-linux-amd64

--- a/.github/workflows/docker-build-and-publish-linux-arm64.yml
+++ b/.github/workflows/docker-build-and-publish-linux-arm64.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docker:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == format('refs/heads/{0}', vars.NIGHTLY_BRANCH) }}
     runs-on: ubuntu-24.04-arm64
     steps: # See https://docs.docker.com/build/ci/github-actions/multi-platform/
       - name: Login to DockerHub
@@ -24,4 +24,4 @@ jobs:
         with:
           platforms: linux/arm64
           push: true
-          tags: nodejs/devcontainer:nightly-linux-arm64
+          tags: ${{ vars.DOCKERHUB_IMAGE }}:nightly-linux-arm64

--- a/.github/workflows/docker-build-and-publish-linux-arm64.yml
+++ b/.github/workflows/docker-build-and-publish-linux-arm64.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   docker:
     if: ${{ github.ref == format('refs/heads/{0}', vars.NIGHTLY_BRANCH) }}
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     steps: # See https://docs.docker.com/build/ci/github-actions/multi-platform/
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/docker-build-and-publish-linux-arm64.yml
+++ b/.github/workflows/docker-build-and-publish-linux-arm64.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Image
+name: Build and Publish Linux ARM64 Image
 
 on:
   workflow_dispatch: # allows us to trigger runs manually in the GitHub UI
@@ -7,7 +7,8 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-24.04-arm64
     steps: # See https://docs.docker.com/build/ci/github-actions/multi-platform/
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -15,15 +16,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: true
-          tags: nodejs/devcontainer:nightly
+          tags: nodejs/devcontainer:nightly-linux-arm64

--- a/.github/workflows/docker-merge.yml
+++ b/.github/workflows/docker-merge.yml
@@ -4,10 +4,9 @@ on:
   workflow_run:  # Fires when any of the specified workflows complete
     workflows: ["Build and Publish Linux ARM64 Image", "Build and Publish Linux AMD64 Image"]
     types: [completed]
-    branches: [main]
 
 env:
-  IMAGE: nodejs/devcontainer
+  IMAGE: ${{ vars.DOCKERHUB_IMAGE }}
   REGISTRY: docker.io
 
 concurrency:  # ensure only one merge runs at a time
@@ -16,7 +15,7 @@ concurrency:  # ensure only one merge runs at a time
 
 jobs:
   merge:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == vars.NIGHTLY_BRANCH }}
     runs-on: ubuntu-latest
     steps:
       - name: Login to DockerHub

--- a/.github/workflows/docker-merge.yml
+++ b/.github/workflows/docker-merge.yml
@@ -1,0 +1,47 @@
+name: Merge images
+
+on:
+  workflow_run:  # Fires when any of the specified workflows complete
+    workflows: ["Build and Publish Linux ARM64 Image", "Build and Publish Linux AMD64 Image"]
+    types: [completed]
+    branches: [main]
+
+env:
+  IMAGE: nodejs/devcontainer
+  REGISTRY: docker.io
+
+concurrency:  # ensure only one merge runs at a time
+  group: merge-manifest
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with: # these are defined in the GitHub Secrets UI
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Merge the multiple architecture-specific images into a single multi-arch image.
+      # If images for other architectures do not exist in the registry yet, this step will fail.
+      # It will only succeed when at least one image for each architecture has been built and pushed.
+      # If images for other architectures are being built and the ones in the registry
+      # are old, it only updates the nightly tag for the architecture that triggered this
+      # workflow. When images for other architectures are built successfully later, they will
+      # trigger this workflow again and merge the updated images.
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            -t ${REGISTRY}/${IMAGE}:nightly \
+            ${REGISTRY}/${IMAGE}:nightly-linux-amd64 \
+            ${REGISTRY}/${IMAGE}:nightly-linux-arm64
+
+      - name: Verify multi-arch manifest
+        run: |
+          docker buildx imagetools inspect ${REGISTRY}/${IMAGE}:nightly


### PR DESCRIPTION
Using one workflow to build for multiple platforms can lead to timeout errors if one of them takes too long (especially when there's emulation), and no images would be published even when only one of them fails.

This split the build workflows into different files based on the platform that publish the images to platform-specific nightly channels, and add a new workflow to merge the platform-specific nightlies into one nightly channel, so that
when one platform fails to build, others can still be updated. This also allows us to build the arm64 images without emulation which would be less likely to time out.