### PR TITLE
Fix permission and make ninja build cache work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,16 @@ RUN echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep
 ENV DEBIAN_FRONTEND=1
 ENV PATH=/usr/lib/ccache:$PATH
 
-COPY --chown=root:developer ./scripts/ /home/developer/scripts/
+# Copy scripts and make them executable by both root and developer
+COPY --chown=root:developer --chmod=0755 ./scripts/ /home/developer/scripts/
 RUN /home/developer/scripts/install.sh
-RUN /home/developer/scripts/mkdir.sh
 RUN /home/developer/scripts/ccache.sh
+
+USER developer
 RUN /home/developer/scripts/clone.sh
 RUN /home/developer/scripts/build.sh
-RUN make install -C /home/developer/nodejs/node
-RUN /home/developer/scripts/ncu.sh
 
+ENV PATH=/home/developer/.local/bin:$PATH
 WORKDIR /home/developer/nodejs/node
+RUN /home/developer/scripts/install-node.sh
+RUN /home/developer/scripts/ncu.sh

--- a/scripts/clone.sh
+++ b/scripts/clone.sh
@@ -2,8 +2,9 @@
 
 set -e # Exit with nonzero exit code if anything fails 
 
+mkdir -p /home/developer/nodejs
 cd /home/developer/nodejs
 git clone https://github.com/nodejs/node.git --single-branch --branch main --depth 1
 cd /home/developer/nodejs/node
 git remote add upstream https://github.com/nodejs/node.git
-git fetch upstream
+git restore-mtime  # Restore file modification times to commit times for build cache to match.

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e # Exit with nonzero exit code if anything fails
+
+make install PREFIX=/home/developer/.local -C /home/developer/nodejs/node
+echo '' >> /home/developer/.bashrc
+echo 'export PATH=/home/developer/.local/bin:$PATH' >> /home/developer/.bashrc

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,7 +20,8 @@ package_list="
   pkg-config \
   locales \
   gpg \
-  wget"
+  wget \
+  git-restore-mtime"
 
 # Install Packages
 apt-get update

--- a/scripts/mkdir.sh
+++ b/scripts/mkdir.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -e # Exit with nonzero exit code if anything fails 
-
-mkdir /home/developer/nodejs
-mkdir -p /home/developer/ninja/out/Release

--- a/scripts/post-checkout
+++ b/scripts/post-checkout
@@ -1,0 +1,2 @@
+#!/bin/bash
+git-restore-mtime


### PR DESCRIPTION
This patch fixes the permission, so that the node distribution from the local build as well as node-core-utils are installed as the developer, not as root, which is less likely to incur permission issues.

This also uses git-mtime-restore to match the mtime of the project files with the timestamp from git, so that when a devcontainer is mounted on the working directory, ninja can easily pick up the cache already in the container and enable fast incremental builds. Update the README accordingly to provide information about how to mount the project to pick up the build cache.