### PR TITLE
Use one orchestrator workflow to trigger platform specific builds

### DIFF
--- a/.github/workflows/docker-build-and-publish-linux-amd64.yml
+++ b/.github/workflows/docker-build-and-publish-linux-amd64.yml
@@ -2,12 +2,10 @@ name: Build and Publish Linux AMD64 Image
 
 on:
   workflow_dispatch: # allows us to trigger runs manually in the GitHub UI
-  schedule:
-    - cron:  '0 0 * * *' # runs nightly
+  workflow_call: # allows this workflow to be called by another workflow
 
 jobs:
   docker:
-    if: ${{ github.ref == format('refs/heads/{0}', vars.NIGHTLY_BRANCH) }}
     runs-on: ubuntu-24.04
     steps: # See https://docs.docker.com/build/ci/github-actions/multi-platform/
       - name: Login to DockerHub

--- a/.github/workflows/docker-build-and-publish-linux-arm64.yml
+++ b/.github/workflows/docker-build-and-publish-linux-arm64.yml
@@ -2,12 +2,10 @@ name: Build and Publish Linux ARM64 Image
 
 on:
   workflow_dispatch: # allows us to trigger runs manually in the GitHub UI
-  schedule:
-    - cron:  '0 0 * * *' # runs nightly
+  workflow_call: # allows this workflow to be called by another workflow
 
 jobs:
   docker:
-    if: ${{ github.ref == format('refs/heads/{0}', vars.NIGHTLY_BRANCH) }}
     runs-on: ubuntu-24.04-arm
     steps: # See https://docs.docker.com/build/ci/github-actions/multi-platform/
       - name: Login to DockerHub

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,25 @@
+name: Nightly build orchestrator
+
+on:
+  workflow_dispatch: # allows us to trigger runs manually in the GitHub UI
+  repository_dispatch: # allows us to trigger runs from an external repository
+  schedule:
+    - cron:  '0 0 * * *' # runs nightly
+
+# When any of the build workflows complete successfully on the nightly branch,
+# the merge workflow will be triggered by those workflows directly to update
+# the build for that platform. These are run independently and concurrently,
+# if any of them fail, at worst the image for that specific platform won't be
+# updated, but at least one usable image for a platform is always available,
+# which is better than dragging the updates for all platforms to wait
+# for one platform to be fixed.
+jobs:
+  call_build_arm64:
+    if: ${{ github.ref == format('refs/heads/{0}', vars.NIGHTLY_BRANCH) }}
+    uses: ./.github/workflows/docker-build-and-publish-linux-arm64.yml
+    secrets: inherit
+
+  call_build_amd64:
+    if: ${{ github.ref == format('refs/heads/{0}', vars.NIGHTLY_BRANCH) }}
+    uses: ./.github/workflows/docker-build-and-publish-linux-amd64.yml
+    secrets: inherit

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: Nightly build orchestrator
+name: Nightly Build Orchestrator
 
 on:
   workflow_dispatch: # allows us to trigger runs manually in the GitHub UI


### PR DESCRIPTION
So that it's easier to trigger the builds from an external repository.

Fixes: https://github.com/nodejs/devcontainer/issues/20