### PR TITLE
fix: using `--depth 1` makes `git-restore-mtime` moot

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To use it as a devcontainer, create a `.devcontainer/devcontainer.json` file in 
   "mounts": [
     "source=build-cache,target=/home/developer/nodejs/node/out,type=volume"
   ],
-  "postCreateCommand": "git restore-mtime"
+  "postCreateCommand": ""
 }
 ```
 
@@ -42,15 +42,6 @@ For example, to use it with Visual Studio Code, use the "Dev Containers: Reopen 
 - If you want to build the project in the container, run with `ninja` (rather than just `make`):
   - To build the release build, run `ninja -C out/Release`
   - The container comes with a release build that can be picked up by `ninja`. As long as your mounted local checkout is not too far behind the checkout in the container, incremental builds should be fast.
-  - If you notice that the build is not picking up your changes after checking out a different branch, run `git restore-mtime` in the container to sync the mtimes of the files in your checkout with the git commit timestamps.
-  - You can also set up a git hook to sync the mtime automatically on checkout to keep the build cache effective. From the container, run:
-
-    ```bash
-    mkdir -p /home/developer/nodejs/node/.git/hooks
-    cp /home/developer/scripts/post-checkout /home/developer/nodejs/node/.git/hooks/post-checkout
-    ```
-
-    Note that if you install this git hook to your mounted project, and you still wish to run `git checkout` from you local system, you will need to install [`git-restore-mtime`](https://github.com/MestreLion/git-tools) on your local system as well.
 
 ### Personal Configuration
 

--- a/scripts/clone.sh
+++ b/scripts/clone.sh
@@ -4,7 +4,6 @@ set -e # Exit with nonzero exit code if anything fails
 
 mkdir -p /home/developer/nodejs
 cd /home/developer/nodejs
-git clone https://github.com/nodejs/node.git --single-branch --branch main --depth 1
+git clone https://github.com/nodejs/node.git --depth 1
 cd /home/developer/nodejs/node
 git remote add upstream https://github.com/nodejs/node.git
-git restore-mtime  # Restore file modification times to commit times for build cache to match.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,8 +20,7 @@ package_list="
   pkg-config \
   locales \
   gpg \
-  wget \
-  git-restore-mtime"
+  wget"
 
 # Install Packages
 apt-get update

--- a/scripts/post-checkout
+++ b/scripts/post-checkout
@@ -1,2 +1,0 @@
-#!/bin/bash
-git-restore-mtime


### PR DESCRIPTION
We can use one or the other, but using both doesn't make much sense (because all files are marked as introduced in the uniq commit in the history), or I'm missing something.
Same for `--single-branch`, and IMO specifying a branch name is a bad idea in the unlikely case where nodejs/node would change its default branch name again.

Currently this PR takes the root of keeping `--depth 1` and getting rid of `git-restore-mtime` to minimize the image size, but we could go the other way around.