### PR TITLE
Fix the docker-merge workflow

### DIFF
--- a/.github/workflows/docker-build-and-publish-linux-amd64.yml
+++ b/.github/workflows/docker-build-and-publish-linux-amd64.yml
@@ -23,3 +23,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ vars.DOCKERHUB_IMAGE }}:nightly-linux-amd64
+
+  merge:
+    needs: [docker]
+    uses: ./.github/workflows/docker-merge.yml
+    secrets: inherit

--- a/.github/workflows/docker-build-and-publish-linux-arm64.yml
+++ b/.github/workflows/docker-build-and-publish-linux-arm64.yml
@@ -23,3 +23,8 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: ${{ vars.DOCKERHUB_IMAGE }}:nightly-linux-arm64
+
+  merge:
+    needs: [docker]
+    uses: ./.github/workflows/docker-merge.yml
+    secrets: inherit

--- a/.github/workflows/docker-merge.yml
+++ b/.github/workflows/docker-merge.yml
@@ -1,9 +1,8 @@
 name: Merge images
 
 on:
-  workflow_run:  # Fires when any of the specified workflows complete
-    workflows: ["Build and Publish Linux ARM64 Image", "Build and Publish Linux AMD64 Image"]
-    types: [completed]
+  workflow_dispatch:  # allow explicit dispatches from arch-specific builds
+  workflow_call:    # allow this workflow to be called by another workflow
 
 env:
   IMAGE: ${{ vars.DOCKERHUB_IMAGE }}
@@ -15,7 +14,6 @@ concurrency:  # ensure only one merge runs at a time
 
 jobs:
   merge:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == vars.NIGHTLY_BRANCH }}
     runs-on: ubuntu-latest
     steps:
       - name: Login to DockerHub


### PR DESCRIPTION
https://redirect.github.com/nodejs/devcontainer/pull/21 broke the merge workflow because the per-platform workflows triggered by the orchestrator workflow cannot trigger the merge workflow via the workflow_run trigger. As such, only the per-platform tags have been published and the aggregate tag has not been updated. Fix it by directly calling the merge workflow in the per-platform workflows instead.